### PR TITLE
Add responsive navbar for service sections

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,15 +1,17 @@
 import React from 'react'
+import Navbar from './components/Navbar'
 
 const services = [
-  { title: 'Redes', desc: 'Diseño, cableado estructurado, Wi‑Fi empresarial y routing seguro.' },
-  { title: 'CCTV', desc: 'Cámaras IP, NVR/DVR, monitoreo remoto y video‑análisis.' },
-  { title: 'Soporte', desc: 'Mantenimiento preventivo/correctivo, Help Desk y continuidad.' }
+  { id: 'redes', title: 'Redes', desc: 'Diseño, cableado estructurado, Wi‑Fi empresarial y routing seguro.' },
+  { id: 'cctv', title: 'CCTV', desc: 'Cámaras IP, NVR/DVR, monitoreo remoto y video‑análisis.' },
+  { id: 'soporte', title: 'Soporte', desc: 'Mantenimiento preventivo/correctivo, Help Desk y continuidad.' }
 ]
 
 export default function App() {
   return (
     <div>
-      <header className="bg-gradient-to-r from-[#591010] to-[#10593e] text-white">
+      <Navbar />
+      <header id="inicio" className="bg-gradient-to-r from-[#591010] to-[#10593e] text-white">
         <div className="max-w-6xl mx-auto px-6 py-16">
           <h1 className="text-4xl md:text-6xl font-extrabold tracking-tight">Aletech</h1>
           <p className="mt-4 text-lg md:text-xl opacity-90">
@@ -34,7 +36,7 @@ export default function App() {
           <p className="text-neutral-600 mt-2">Integración llave en mano con garantía y documentación.</p>
           <div className="grid md:grid-cols-3 gap-6 mt-8">
             {services.map((s) => (
-              <div key={s.title} className="rounded-2xl border border-neutral-200 bg-white p-6 shadow-sm">
+              <div key={s.id} id={s.id} className="rounded-2xl border border-neutral-200 bg-white p-6 shadow-sm">
                 <h3 className="text-xl font-semibold">{s.title}</h3>
                 <p className="mt-2 text-neutral-600">{s.desc}</p>
               </div>

--- a/src/components/Navbar.jsx
+++ b/src/components/Navbar.jsx
@@ -1,0 +1,46 @@
+import React, { useState } from 'react'
+
+const links = [
+  { href: '#inicio', label: 'Inicio' },
+  { href: '#servicios', label: 'Soluciones' },
+  { href: '#redes', label: 'Redes' },
+  { href: '#cctv', label: 'CCTV' },
+  { href: '#soporte', label: 'Soporte' },
+  { href: '#contacto', label: 'Contacto' }
+]
+
+export default function Navbar() {
+  const [open, setOpen] = useState(false)
+
+  return (
+    <nav className="bg-white border-b border-neutral-200">
+      <div className="max-w-6xl mx-auto px-6 py-4 flex flex-col md:flex-row md:items-center md:justify-between">
+        <div className="flex items-center justify-between">
+          <a href="#inicio" className="text-xl font-semibold text-[#591010]">Aletech</a>
+          <button
+            className="md:hidden text-neutral-700"
+            onClick={() => setOpen(!open)}
+            aria-label="Abrir menú"
+          >
+            <svg className="h-6 w-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M4 6h16M4 12h16M4 18h16" />
+            </svg>
+          </button>
+        </div>
+        <ul className={`mt-4 md:mt-0 space-y-2 md:space-y-0 md:flex md:items-center md:gap-6 ${open ? 'block' : 'hidden'}`}>
+          {links.map(link => (
+            <li key={link.href}>
+              <a
+                href={link.href}
+                className="block py-2 md:py-0 text-neutral-700 hover:text-[#591010]"
+                onClick={() => setOpen(false)}
+              >
+                {link.label}
+              </a>
+            </li>
+          ))}
+        </ul>
+      </div>
+    </nav>
+  )
+}


### PR DESCRIPTION
## Summary
- implement responsive navigation bar with menus for Inicio, Soluciones, Redes, CCTV, Soporte and Contacto
- tag service cards with IDs to support in-page navigation

## Testing
- npm test (fails: missing script)
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68b36b0afe648323ad7833605a68d1d3