### PR TITLE
feat: add service quotation tool

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,9 +1,11 @@
 import React from 'react'
 import Navbar from './components/Navbar'
+import Cotizador from './components/Cotizador'
 
 const services = [
   { id: 'redes', title: 'Redes', desc: 'Diseño, cableado estructurado, Wi‑Fi empresarial y routing seguro.' },
   { id: 'cctv', title: 'CCTV', desc: 'Cámaras IP, NVR/DVR, monitoreo remoto y video‑análisis.' },
+  { id: 'aire', title: 'Aire acondicionado', desc: 'Venta e instalación profesional de mini splits y sistemas centrales.' },
   { id: 'soporte', title: 'Soporte', desc: 'Mantenimiento preventivo/correctivo, Help Desk y continuidad.' }
 ]
 
@@ -22,7 +24,7 @@ export default function App() {
                className="rounded-2xl bg-white/10 backdrop-blur px-5 py-2.5 text-white border border-white/20 hover:bg-white/20 transition">
               WhatsApp
             </a>
-            <a href="#contacto"
+            <a href="#cotizador"
                className="rounded-2xl bg-white text-[#591010] px-5 py-2.5 font-semibold hover:shadow">
               Cotiza ahora
             </a>
@@ -41,6 +43,13 @@ export default function App() {
                 <p className="mt-2 text-neutral-600">{s.desc}</p>
               </div>
             ))}
+          </div>
+        </section>
+
+        <section id="cotizador" className="mt-16">
+          <h2 className="text-2xl md:text-3xl font-bold text-neutral-900">Cotizador</h2>
+          <div className="mt-4">
+            <Cotizador />
           </div>
         </section>
 

--- a/src/components/Cotizador.jsx
+++ b/src/components/Cotizador.jsx
@@ -1,0 +1,111 @@
+import { useState } from 'react'
+
+const services = [
+  { id: 'cctv', label: 'Instalación CCTV' },
+  { id: 'aire', label: 'Instalación de aire acondicionado' },
+  { id: 'redes', label: 'Redes' },
+  { id: 'soporte', label: 'Soporte' }
+]
+
+const questions = {
+  cctv: { id: 'cameras', text: '¿Cuántas cámaras necesitas?', options: ['1-4', '5-8', '9+'] },
+  aire: { id: 'capacidad', text: 'Capacidad requerida (BTU)?', options: ['1-2 ton', '2-3 ton', '3+ ton'] },
+  redes: { id: 'tipo', text: 'Tipo de red', options: ['Doméstica', 'Empresarial'] },
+  soporte: { id: 'modalidad', text: 'Tipo de soporte', options: ['Preventivo', 'Correctivo', 'Help Desk'] }
+}
+
+const packages = {
+  cctv: [
+    { id: 'basico1', name: 'Kit 4 cámaras 2MP con cableado para exterior', price: 5099 }
+  ],
+  aire: [
+    { id: 'mini', name: 'Mini split 1.5 ton con instalación básica', price: 8999 }
+  ],
+  redes: [
+    { id: 'home', name: 'Paquete red doméstica hasta 10 nodos', price: 3999 }
+  ],
+  soporte: [
+    { id: 'mensual', name: 'Plan de soporte remoto mensual', price: 999 }
+  ]
+}
+
+export default function Cotizador() {
+  const [step, setStep] = useState(1)
+  const [service, setService] = useState('')
+  const [answer, setAnswer] = useState('')
+
+  const reset = () => {
+    setStep(1)
+    setService('')
+    setAnswer('')
+  }
+
+  const handleService = (e) => {
+    setService(e.target.value)
+    setStep(2)
+  }
+
+  const handleAnswer = (e) => {
+    setAnswer(e.target.value)
+    setStep(3)
+  }
+
+  return (
+    <div className="rounded-2xl border border-neutral-200 bg-white p-6 shadow-sm">
+      {step === 1 && (
+        <div>
+          <h3 className="text-xl font-semibold">Cotiza tu servicio</h3>
+          <p className="mt-2 text-neutral-600">Selecciona un servicio para comenzar.</p>
+          <select
+            className="mt-4 w-full rounded-md border p-2"
+            value={service}
+            onChange={handleService}
+          >
+            <option value="">-- Selecciona --</option>
+            {services.map(s => (
+              <option key={s.id} value={s.id}>{s.label}</option>
+            ))}
+          </select>
+        </div>
+      )}
+
+      {step === 2 && (
+        <div>
+          <h3 className="text-xl font-semibold">{services.find(s => s.id === service)?.label}</h3>
+          <p className="mt-2 text-neutral-600">{questions[service].text}</p>
+          <select
+            className="mt-4 w-full rounded-md border p-2"
+            value={answer}
+            onChange={handleAnswer}
+          >
+            <option value="">-- Selecciona --</option>
+            {questions[service].options.map(opt => (
+              <option key={opt} value={opt}>{opt}</option>
+            ))}
+          </select>
+        </div>
+      )}
+
+      {step === 3 && (
+        <div>
+          <h3 className="text-xl font-semibold">Recomendaciones</h3>
+          <p className="mt-2 text-neutral-600">Basado en tus respuestas:</p>
+          <ul className="mt-4 space-y-3">
+            {(packages[service] || []).map(pkg => (
+              <li key={pkg.id} className="rounded-md border p-3">
+                <p className="font-medium">{pkg.name}</p>
+                <p className="text-sm text-neutral-600">${pkg.price}</p>
+              </li>
+            ))}
+          </ul>
+          <button
+            className="mt-6 text-sm underline"
+            onClick={reset}
+          >
+            Empezar de nuevo
+          </button>
+        </div>
+      )}
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- add interactive service quotation form with category-specific questions and package recommendations
- expose quotation section in main page and link from hero

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Missing script "lint")*

------
https://chatgpt.com/codex/tasks/task_e_68b3726fce6883239bebd790cd9c2f1d